### PR TITLE
rm redundant param

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -42,10 +42,8 @@ class Similarity(nn.Module):
         self.temp = temp
         self.cos = nn.CosineSimilarity(dim=-1)
 
-    def forward(self, x, y, temp=None):
-        if temp is None:
-            temp = self.temp
-        return self.cos(x, y) / temp
+    def forward(self, x, y):
+        return self.cos(x, y) / self.temp
 
 
 class Pooler(nn.Module):


### PR DESCRIPTION
It seems that the temp parameter will only be passed in at `Similarity` initialization, so redundant parameters are removed.