### PR TITLE
fix for DDP

### DIFF
--- a/simcse/models.py
+++ b/simcse/models.py
@@ -89,7 +89,8 @@ def cl_init(cls, config):
     """
     cls.pooler_type = cls.model_args.pooler_type
     cls.pooler = Pooler(cls.model_args.pooler_type)
-    cls.mlp = MLPLayer(config)
+    if cls.model_args.pooler_type == "cls":
+        cls.mlp = MLPLayer(config)
     cls.sim = Similarity(temp=cls.model_args.temp)
     cls.init_weights()
 
@@ -277,7 +278,7 @@ class BertForCL(BertPreTrainedModel):
     def __init__(self, config, *model_args, **model_kargs):
         super().__init__(config)
         self.model_args = model_kargs["model_args"]
-        self.bert = BertModel(config)
+        self.bert = BertModel(config, add_pooling_layer=False)
 
         if self.model_args.do_mlm:
             self.lm_head = BertLMPredictionHead(config)
@@ -336,7 +337,7 @@ class RobertaForCL(RobertaPreTrainedModel):
     def __init__(self, config, *model_args, **model_kargs):
         super().__init__(config)
         self.model_args = model_kargs["model_args"]
-        self.roberta = RobertaModel(config)
+        self.roberta = RobertaModel(config, add_pooling_layer=False)
 
         if self.model_args.do_mlm:
             self.lm_head = RobertaLMHead(config)


### PR DESCRIPTION
When using multi-GPU with DDP, errors occur as follows,

```
RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one. This error indicates that your module has parameters that were not used in producing loss. You can enable unused parameter detection by passing the keyword argument `find_unused_parameters=True` to `torch.nn.parallel.DistributedDataParallel`, and by
making sure all `forward` function outputs participate in calculating loss.
If you already have done the above, then the distributed data parallel module wasn't able to locate the output tensors in the return value of your module's `forward` function. Please include the loss function and the structure of the return value of `forward` of your module when reporting this issue (e.g. list, dict, iterable).
```

This is to remove the `unused_parameters` in the BERT and RoBERTa models. 
