### PR TITLE
fixed the accidentally masking problem for input_ids with --do_mlm

### DIFF
--- a/train.py
+++ b/train.py
@@ -500,6 +500,7 @@ def main():
             """
             Prepare masked tokens inputs/labels for masked language modeling: 80% MASK, 10% random, 10% original.
             """
+            inputs = inputs.clone()
             labels = inputs.clone()
             # We sample a few tokens in each sequence for MLM training (with probability `self.mlm_probability`)
             probability_matrix = torch.full(labels.shape, self.mlm_probability)


### PR DESCRIPTION
Hi! Thanks for your open source code for SimCSE.

In your code, `input_ids` will be accidentally applied 15% masking if `--do_mlm`.
I have read your SimCSE paper carefully. In my understanding, if we add `--do_mlm`, `input_ids` is for contrastive learning and `mlm_input_ids` is for MLM training, so `input_ids` should not have the 15% masking. However, when printing out the mini-batch, `input_ids` also has 15% masking, and `(input_ids == mlm_input_ids).all()` is True. I show the results here: (`103` is the mask token id of `bert-base-uncased`)


```
(Pdb) input_ids
tensor([[[  101,  2023,  3291,  ...,  1996,  4942,   102],
         [  101,  2023,   103,  ...,  1996,   103,   102]],

        [[  101, 18887,  1005,  ...,     0,     0,     0],
         [  101, 18887,  1005,  ...,     0,     0,     0]],

        [[  101, 23564,  3593,  ...,   103,  2007,   102],
         [  101, 23564,  3593,  ...,  6736,  2007,   102]],

        ...,

        [[  101,   103, 18730,  ...,     0,     0,     0],
         [  101,  1996, 18730,  ...,     0,     0,     0]],

        [[  101, 17710, 23385,  ...,  7721,  4547,   102],
         [  101, 17710, 23385,  ...,  7721,  4547,   102]],

        [[  101,  2096,  1996,  ...,     0,     0,     0],
         [  101,   103,  1996,  ...,     0,     0,     0]]], device='cuda:0')

(Pdb) mlm_input_ids
tensor([[[  101,  2023,  3291,  ...,  1996,  4942,   102],
         [  101,  2023,   103,  ...,  1996,   103,   102]],

        [[  101, 18887,  1005,  ...,     0,     0,     0],
         [  101, 18887,  1005,  ...,     0,     0,     0]],

        [[  101, 23564,  3593,  ...,   103,  2007,   102],
         [  101, 23564,  3593,  ...,  6736,  2007,   102]],

        ...,

        [[  101,   103, 18730,  ...,     0,     0,     0],
         [  101,  1996, 18730,  ...,     0,     0,     0]],

        [[  101, 17710, 23385,  ...,  7721,  4547,   102],
         [  101, 17710, 23385,  ...,  7721,  4547,   102]],

        [[  101,  2096,  1996,  ...,     0,     0,     0],
         [  101,   103,  1996,  ...,     0,     0,     0]]], device='cuda:0')
         
(Pdb) (input_ids == mlm_input_ids).all()
tensor(True, device='cuda:0')
```

As a result, I add a line `inputs = inputs.clone()` in the `mask_tokens()` function in your `train.py`. It should solve the problem.