### PR TITLE
Remove --f16 \ from run_unsup_example.sh

### DIFF
--- a/run_unsup_example.sh
+++ b/run_unsup_example.sh
@@ -22,5 +22,4 @@ python train.py \
     --temp 0.05 \
     --do_train \
     --do_eval \
-    --fp16 \
     "$@"


### PR DESCRIPTION
The --f16 is used only for Cuda devices and since the example is for CPU devices, removing --f16 \ corrects the problem.