### PR TITLE
Fix deprecated inspect.getargspec

### DIFF
--- a/SentEval/senteval/utils.py
+++ b/SentEval/senteval/utils.py
@@ -86,7 +86,7 @@ def get_optimizer(s):
         raise Exception('Unknown optimization method: "%s"' % method)
 
     # check that we give good parameters to the optimizer
-    expected_args = inspect.getargspec(optim_fn.__init__)[0]
+    expected_args = inspect.getfullargspec(optim_fn.__init__)[0]
     assert expected_args[:2] == ['self', 'params']
     if not all(k in expected_args[2:] for k in optim_params.keys()):
         raise Exception('Unexpected parameters: expected "%s", got "%s"' % (


### PR DESCRIPTION
The inspect.getargspec call is deprecated, [getfullargspec](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) can and should be used instead.

The first element which we are accessing, the parameter names, are equivalent in both functions.

Fixes #218.